### PR TITLE
Update 0093.复原IP地址.md

### DIFF
--- a/problems/0093.复原IP地址.md
+++ b/problems/0093.复原IP地址.md
@@ -227,7 +227,7 @@ private:
 public:
     vector<string> restoreIpAddresses(string s) {
         result.clear();
-        if (s.size() > 12) return result; // 算是剪枝了
+        if (s.size() < 4 || s.size() > 12) return result; // 算是剪枝了
         backtracking(s, 0, 0);
         return result;
     }


### PR DESCRIPTION
1. 优化C++版本剪枝
当字符串长度小于4时，无法组成正确的IP地址，直接返回。

关于判断是否为数字的部分，是否有必要（题目明确说明s仅由数字组成）
[从解题角度可以删去，保留的话增加容错，个人意见]